### PR TITLE
Fix Windows 10 enterprise autologon

### DIFF
--- a/WinImageBuilder.psm1
+++ b/WinImageBuilder.psm1
@@ -336,6 +336,12 @@ function Generate-UnattendXml {
     $xsltArgs["versionMajor"] = $image.ImageVersion.Major
     $xsltArgs["versionMinor"] = $image.ImageVersion.Minor
     $xsltArgs["installationType"] = $image.ImageInstallationType
+    # Note(avladu): This is a hack to properly set autologon on Windows 10 Enterprise,
+    # as the Administrator account is enabled, unlike for other client Windows versions.
+    if ($image.ImageVersion.Major -eq 10 -and $image.ImageVersion.Minor -eq 0 -and `
+        $image.ImageName -like '*Enterprise*') {
+        $xsltArgs["installationType"] = 'Server'
+    }
     $xsltArgs["administratorPassword"] = $administratorPassword
 
     if ($productKey) {


### PR DESCRIPTION
Fix Windows 10 Enterprise image generation

Fixes
#254

On Windows 10 Enterprise, Administrator account is enabled, thus
the behaviour for the autologon is similar to the one of a Server
version.

Also, the Autologon information disappears from the registry and it
needs to be created at the first boot.