### PR TITLE
Added option to install Qemu Guest Agents

### DIFF
--- a/Config.psm1
+++ b/Config.psm1
@@ -109,6 +109,15 @@ function Get-AvailableConfigOptions {
         @{"Name" = "virtio_base_path"; "GroupName" = "drivers";
           "Description" = "The location where the VirtIO drivers are found.
                            For example, the location of a mounted VirtIO ISO. VirtIO versions supported >=0.1.6.x"},
+        @{"Name" = "install_qemu_ga"; "GroupName" = "custom";"DefaultValue" = "False";
+          "Description" = "Installs QEMU guest agent services from the Fedora VirtIO website.
+                           Defaults to 'False' (no installation will be performed).
+                           If set to 'True', the following MSI installer will be downloaded and installed:
+                             * for x86: https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/archive-qemu-ga/qemu-ga-win-100.0.0.0-3.el7ev/qemu-ga-x86.msi
+                             * for x64: https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/archive-qemu-ga/qemu-ga-win-100.0.0.0-3.el7ev/qemu-ga-x64.msi
+                           The value can be changed to a custom URL, to allow other QEMU guest agent versions to be installed.
+                           Note: QEMU guest agent requires VirtIO drivers to be present on the image.
+                          "},
         @{"Name" = "drivers_path"; "GroupName" = "drivers";
           "Description" = "The location where additional drivers that are needed for the image are located."},
         @{"Name" = "install_updates"; "GroupName" = "updates"; "DefaultValue" = $false; "AsBoolean" = $true;

--- a/Examples/windows-image-config-example.ini
+++ b/Examples/windows-image-config-example.ini
@@ -133,6 +133,19 @@ virtio_iso_path=""
 virtio_base_path=""
 # The location where additional drivers that are needed for the image are located.
 drivers_path=""
+[custom]
+# Installs QEMU guest agent services from the Fedora VirtIO website.
+# Defaults to 'False' (no installation will be performed).
+# If set to 'True', the following MSI installer will be downloaded and installed:
+# * for x86: https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/archive-qemu-ga/qemu-ga-win-100.0.0.0-3.el7ev/qemu-ga-x86.msi
+# * for x64: https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/archive-qemu-ga/qemu-ga-win-100.0.0.0-3.el7ev/qemu-ga-x64.msi
+# The value can be changed to a custom URL, to allow other QEMU guest agent versions to be installed.
+# Note: QEMU guest agent requires VirtIO drivers to be present on the image.
+install_qemu_ga=False
+# Set a custom timezone for the Windows image.
+time_zone=""
+# Set custom ntp servers(space separated) for the Windows image
+ntp_servers=""
 [updates]
 # If set to true, the latest updates will be downloaded and installed.
 install_updates=False
@@ -181,8 +194,3 @@ cloudbase_init_unattended_config_path=""
 # If set, the Cloudbase-Init service will be run under Local System account.
 # By default, a user named cloudbase-init with admin rights is created and used.
 cloudbase_init_use_local_system=False
-[custom]
-# Set a custom timezone for the Windows image.
-time_zone=""
-# Set custom ntp servers(space separated) for the Windows image
-ntp_servers=""

--- a/Tests/WinImageBuilder.Tests.ps1
+++ b/Tests/WinImageBuilder.Tests.ps1
@@ -237,6 +237,7 @@ Describe "Test New-WindowsOnlineImage" {
 
     It "Should create an online image" {
         New-WindowsOnlineImage -ConfigFilePath $fakeConfigPath | Should -Contain 0
+        Remove-Item -Force -ErrorAction SilentlyContinue "${fakeConfigPath}.offline"
     }
 
     It "should run all mocked commands" {

--- a/UnattendResources/Logon.ps1
+++ b/UnattendResources/Logon.ps1
@@ -472,6 +472,35 @@ function Enable-ShutdownWithoutLogon {
     Write-Log "ShutdownWithoutLogon" "Shutdown without logon was enabled"
 }
 
+function Install-QemuGuestAgent {
+    $qemuServices = Get-Service "*qemu*"
+    if ($qemuServices -and $qemuServices.Count -eq 2) {
+        Write-Log "QemuGa" "Qemu Guest Agents are already installed."
+        return
+    }
+    $qemuGaMsiPath = Join-Path $resourcesDir "qemu-ga.msi"
+    $qemuGaMsiLog = Join-Path $resourcesDir "qemu-ga.log"
+
+    $params = '-i "{0}" /qn /log "{1}"' -f @($qemuGaMsiPath, $qemuGaMsiLog)
+    $exitCode = (Start-Process -FilePath msiexec.exe -ArgumentList $params -Wait -Passthru).ExitCode
+    if ($exitCode) {
+        throw "Failed to install Qemu Guest Agent. Exit code: ${exitCode}"
+    }
+
+    $qemuServices = Get-Service "*qemu*"
+
+    if ($qemuServices.Count -ne 2) {
+        throw "Failed to find both Qemu Guest Agent services"
+    }
+    $guestAgentService = $qemuServices | Where-Object {$_.Name -eq "QEMU-GA"}
+    $guestAgentVssService = $qemuServices | Where-Object {$_.Name -eq "QEMU Guest Agent VSS Provider"}
+    if (!$guestAgentService -or !$guestAgentVssService) {
+        throw "Failed to find GA and VSS services"
+    }
+    Write-Log "QemuGa" "Qemu Guest Agents installed successfully."
+}
+
+
 try {
     Write-Log "StatusInitial" "Automated instance configuration started..."
     $psVersion = "PS version {0}." -f $PSVersionTable.PSVersion.ToString()
@@ -532,9 +561,17 @@ try {
         $setCloudbaseInitDelayedStart = Get-IniFileValue -Path $configIniPath -Section "cloudbase_init" -Key "cloudbase_init_delayed_start" `
             -Default $false -AsBoolean
     } catch{}
+    try {
+        $installQemuGuestAgent = Get-IniFileValue -Path $configIniPath -Section "custom" -Key "install_qemu_ga" `
+            -Default "False"
+    } catch{}
 
     if ($productKey) {
         License-Windows $productKey
+    }
+
+    if ($installQemuGuestAgent -and $installQemuGuestAgent -ne 'False') {
+        Install-QemuGuestAgent
     }
 
     Run-CustomScript "RunBeforeWindowsUpdates.ps1"

--- a/WinImageBuilder.psm1
+++ b/WinImageBuilder.psm1
@@ -557,6 +557,34 @@ function Download-CloudbaseInit {
     }
 }
 
+function Download-QemuGuestAgent {
+    Param(
+        [Parameter(Mandatory=$true)]
+        [string]$QemuGuestAgentConfig,
+        [Parameter(Mandatory=$true)]
+        [string]$ResourcesDir,
+        [Parameter(Mandatory=$true)]
+        [string]$OsArch
+    )
+
+    $QemuGuestAgentUrl = $QemuGuestAgentConfig
+    if ($QemuGuestAgentConfig -eq 'True') {
+        $arch = "x86"
+        if ($OsArch -eq "AMD64") {
+            $arch = "x64"
+        }
+        $QemuGuestAgentUrl = "https://fedorapeople.org/groups/virt/virtio-win/direct-downloads" + `
+                             "/archive-qemu-ga/qemu-ga-win-100.0.0.0-3.el7ev/qemu-ga-{0}.msi" -f $arch
+    }
+
+    Write-Log "Downloading QEMU guest agent installer from ${QemuGuestAgentUrl} ..."
+    $dst = Join-Path $ResourcesDir "qemu-ga.msi"
+    Execute-Retry {
+        (New-Object System.Net.WebClient).DownloadFile($QemuGuestAgentUrl, $dst)
+    }
+    Write-Log "QEMU guest agent installer path is: $dst"
+}
+
 function Download-ZapFree {
     Param(
         [Parameter(Mandatory=$true)]
@@ -1676,6 +1704,10 @@ function New-WindowsCloudImage {
             if ($windowsImageConfig.zero_unused_volume_sectors) {
                 Download-ZapFree $resourcesDir ([string]$image.ImageArchitecture)
             }
+            if ($windowsImageConfig.install_qemu_ga -and $windowsImageConfig.install_qemu_ga -ne 'False') {
+                Download-QemuGuestAgent -QemuGuestAgentConfig $windowsImageConfig.install_qemu_ga `
+                    -ResourcesDir $resourcesDir -OsArch ([string]$image.ImageArchitecture)
+            }
             Download-CloudbaseInit -resourcesDir $resourcesDir -osArch ([string]$image.ImageArchitecture) `
                                    -BetaRelease:$windowsImageConfig.beta_release -MsiPath $windowsImageConfig.msi_path `
                                    -CloudbaseInitConfigPath $windowsImageConfig.cloudbase_init_config_path `
@@ -1852,6 +1884,10 @@ function New-WindowsFromGoldenImage {
         }
         if ($windowsImageConfig.zero_unused_volume_sectors) {
             Download-ZapFree $resourcesDir $imageInfo.imageArchitecture
+        }
+        if ($windowsImageConfig.install_qemu_ga -and $windowsImageConfig.install_qemu_ga -ne 'False') {
+            Download-QemuGuestAgent -QemuGuestAgentConfig $windowsImageConfig.install_qemu_ga `
+                -ResourcesDir $resourcesDir -OsArch $imageInfo.imageArchitecture
         }
         Download-CloudbaseInit -resourcesDir $resourcesDir -osArch $imageInfo.imageArchitecture `
                                -BetaRelease:$windowsImageConfig.beta_release -MsiPath $windowsImageConfig.msi_path `


### PR DESCRIPTION
Added option to install Qemu Guest Agents:
[custom]
install_qemu_ga=False

If set to True, it will download and install the Qemu Guest
Agents from Fedora website. The base path for the agents is
https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/archive-qemu-ga/qemu-ga-win-100.0.0.0-3.el7ev/
The downloaded MSI will be chosen depending on the architecture of the
image, x86 or x64.

For example, on x64 images, the following MSI installer will be
downloaded and used:
https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/archive-qemu-ga/qemu-ga-win-100.0.0.0-3.el7ev/qemu-ga-x64.msi
By default, the imaging tools will not install the Qemu Guest
Agents.

The MSI will install two services on the Windows image:

 * QEMU-GA
 * QEMU Guest Agent VSS Provider

The Qemu Guest Agents are useful if the Windows instance runs
on OpenStack (KVM hypervisor is required).

If the Windows instance is managed by OpenStack, runs on KVM and
QEMU-GA service is running, the user password can be changed using
the OpenStack Nova command:

  nova set-password <instance-id>

Requirement1: if the nova command fails, the instance might enter an error
state and you need to reset the instance state:

  nova reset-state <instance-id> --active

Requirement: the Glance image needs to modified in the following way,
BEFORE the instance gets created:

  glance image-update <image_id> --property hw_qemu_guest_agent=True \
  --property os_admin_user=Admin --property os_type=windows

`os_admin_user` is the user that will have the password changed.
Defaults to user 'root'. If 'os_type' property is set
to  'windows', the default user is 'Administrator'.
If you modify the required Glance image properties after you created
the instance, the nova set-password will not function.