### PR TITLE
fix: use correct icmpv6 type for echo request

### DIFF
--- a/UnattendResources/Logon.ps1
+++ b/UnattendResources/Logon.ps1
@@ -451,7 +451,7 @@ function Enable-PingFirewallRules {
     if ($LASTEXITCODE) {
         throw "Failed to enable IPv4 ping firewall rules"
     }
-    netsh.exe advfirewall firewall add rule name="Allow IPv6 ping requests" protocol="icmpv6:8,any" dir=in action=allow
+    netsh.exe advfirewall firewall add rule name="Allow IPv6 ping requests" protocol="icmpv6:128,any" dir=in action=allow
     if ($LASTEXITCODE) {
         throw "Failed to enable IPv6 ping firewall rules"
     }


### PR DESCRIPTION
ICMPv6 uses different message types than ICMPv4. So in order to enable ICMPv6 echo requests we have to used message type 128 instead of 8.  See https://de.wikipedia.org/wiki/ICMPv6 for reference. 