### PR TITLE
Added install_net_3_5 feature for Win 2012R2

### DIFF
--- a/Config.psm1
+++ b/Config.psm1
@@ -67,6 +67,9 @@ function Get-AvailableConfigOptions {
                            It should be a valid VHDX path."},
         @{"Name" = "vmware_tools_path";
           "Description" = "This is a full path to the VMware-tools.exe version that you want to install."},
+        @{"Name" = "install_net_3_5"; "DefaultValue" = $false; "AsBoolean" = $true;
+          "Description" = "If set to true, .NET Framework 3.5 will be installed before the windows updates.
+							This feature applies only ot Windows server 2012 R2."},
         @{"Name" = "custom_resources_path";
           "Description" = "This is the full path of a folder with custom resources which will be used by
                            the custom scripts.

--- a/UnattendResources/Logon.ps1
+++ b/UnattendResources/Logon.ps1
@@ -565,6 +565,10 @@ try {
         $installQemuGuestAgent = Get-IniFileValue -Path $configIniPath -Section "custom" -Key "install_qemu_ga" `
             -Default "False"
     } catch{}
+	try {
+        $install_net_3_5 = Get-IniFileValue -Path $configIniPath -Section "DEFAULT" -Key "install_net_3_5" `
+            -Default "False"
+    } catch {}
 
     if ($productKey) {
         License-Windows $productKey
@@ -572,6 +576,10 @@ try {
 
     if ($installQemuGuestAgent -and $installQemuGuestAgent -ne 'False') {
         Install-QemuGuestAgent
+    }
+
+	if ($install_net_3_5 -and $install_net_3_5 -ne 'False') {
+        Install-WindowsFeature NET-Framework-Features
     }
 
     Run-CustomScript "RunBeforeWindowsUpdates.ps1"


### PR DESCRIPTION
For Windows 2012 R2 installing the .net3.5 feature is impossible after you install the Windows updates.
Reference [here](https://support.microsoft.com/en-us/topic/update-for-the-net-framework-3-5-on-windows-8-windows-8-1-windows-server-2012-and-windows-server-2012-r2-c5c4baac-1708-d32d-2cfb-dd94e4a91b2a)
This PR introduces a parameter that if set to True  .net3.5 will be installed before any updates are installed