### PR TITLE
kubevirt: fix nocloud class name and limited unattend plugins

### DIFF
--- a/Examples/config/kubevirt/cloudbase-init-unattend.conf
+++ b/Examples/config/kubevirt/cloudbase-init-unattend.conf
@@ -21,4 +21,5 @@ allow_reboot=false
 stop_service_on_exit=false
 check_latest_version=false
 
-metadata_services=cloudbaseinit.metadata.services.configdrive.ConfigDriveService,cloudbaseinit.metadata.services.configdrive.NoCloudConfigDriveService,cloudbaseinit.metadata.services.base.EmptyMetadataService
+plugins=cloudbaseinit.plugins.common.mtu.MTUPlugin,cloudbaseinit.plugins.common.sethostname.SetHostNamePlugin,cloudbaseinit.plugins.windows.extendvolumes.ExtendVolumesPlugin
+metadata_services=cloudbaseinit.metadata.services.configdrive.ConfigDriveService,cloudbaseinit.metadata.services.nocloudservice.NoCloudConfigDriveService,cloudbaseinit.metadata.services.base.EmptyMetadataService

--- a/Examples/config/kubevirt/cloudbase-init.conf
+++ b/Examples/config/kubevirt/cloudbase-init.conf
@@ -19,5 +19,4 @@ local_scripts_path=C:\Program Files\Cloudbase Solutions\Cloudbase-Init\LocalScri
 
 first_logon_behaviour=no
 
-metadata_services=cloudbaseinit.metadata.services.configdrive.ConfigDriveService,cloudbaseinit.metadata.services.configdrive.NoCloudConfigDriveService,cloudbaseinit.metadata.services.base.EmptyMetadataService
-
+metadata_services=cloudbaseinit.metadata.services.configdrive.ConfigDriveService,cloudbaseinit.metadata.services.nocloudservice.NoCloudConfigDriveService,cloudbaseinit.metadata.services.base.EmptyMetadataService


### PR DESCRIPTION
Use the correct NoCloudConfigDriveService class path and limited the unattended list of plugins to the 3 that are being set by the installer.