### PR TITLE
Add support for 2k25 virtio drivers

### DIFF
--- a/WinImageBuilder.psm1
+++ b/WinImageBuilder.psm1
@@ -52,7 +52,8 @@ $VirtIODriverMappings = @{
     "2k16" = @(14393, 16299, $true);
     "w10" = @(10240, $MAX_BUILD_NUMBER, $false);
     "2k19" = @(17763, 19999, $true);
-    "2k22" = @(20348, $MAX_BUILD_NUMBER, $true);
+    "2k22" = @(20348, 25999, $true);
+    "2k25" = @(26100, $MAX_BUILD_NUMBER, $true);
 }
 
 $AvailableCompressionFormats = @("tar","gz","zip")


### PR DESCRIPTION
Currently, when building Windows Server 2025 images, we are using the VirtIO driver binaries for Windows Server 2022. This PR introduces a dedicated mapping for 2k25, using the appropriate build numbers.
The build versions are from https://learn.microsoft.com/en-us/windows-server/get-started/windows-server-release-info